### PR TITLE
Refactor incident edges

### DIFF
--- a/bidirectional_ch_one_to_n.go
+++ b/bidirectional_ch_one_to_n.go
@@ -145,11 +145,10 @@ func (graph *Graph) relaxEdgesBiForwardOneToMany(vertex *simpleNode, forwQ *forw
 }
 
 func (graph *Graph) relaxEdgesBiBackwardOneToMany(vertex *simpleNode, backwQ *backwardPropagationHeap, prev map[int64]int64, revDist []float64, cid int64, revProcessed []int64) {
-	vertexList := graph.Vertices[vertex.id].inEdges
-	costList := graph.Vertices[vertex.id].inECost
+	vertexList := graph.Vertices[vertex.id].inIncidentEdges
 	for i := 0; i < len(vertexList); i++ {
-		temp := vertexList[i]
-		cost := costList[i]
+		temp := vertexList[i].vertexID
+		cost := vertexList[i].cost
 		if graph.Vertices[vertex.id].orderPos < graph.Vertices[temp].orderPos {
 			alt := revDist[vertex.id] + cost
 			if revProcessed[temp] != cid || revDist[temp] > alt {

--- a/bidirectional_ch_one_to_n.go
+++ b/bidirectional_ch_one_to_n.go
@@ -123,11 +123,10 @@ func (graph *Graph) ShortestPathOneToMany(source int64, targets []int64) ([]floa
 }
 
 func (graph *Graph) relaxEdgesBiForwardOneToMany(vertex *simpleNode, forwQ *forwardPropagationHeap, prev map[int64]int64, queryDist []float64, cid int64, forwProcessed []int64) {
-	vertexList := graph.Vertices[vertex.id].outEdges
-	costList := graph.Vertices[vertex.id].outECost
+	vertexList := graph.Vertices[vertex.id].outIncidentEdges
 	for i := 0; i < len(vertexList); i++ {
-		temp := vertexList[i]
-		cost := costList[i]
+		temp := vertexList[i].vertexID
+		cost := vertexList[i].cost
 		if graph.Vertices[vertex.id].orderPos < graph.Vertices[temp].orderPos {
 			alt := queryDist[vertex.id] + cost
 			if forwProcessed[temp] != cid || queryDist[temp] > alt {

--- a/bidirectional_relaxation.go
+++ b/bidirectional_relaxation.go
@@ -6,11 +6,10 @@ import (
 
 // relaxEdgesBiForward Edge relaxation in a forward propagation
 func (graph *Graph) relaxEdgesBiForward(vertex *simpleNode, forwQ *forwardPropagationHeap, prev map[int64]int64, queryDist []float64) {
-	vertexList := graph.Vertices[vertex.id].outEdges
-	costList := graph.Vertices[vertex.id].outECost
+	vertexList := graph.Vertices[vertex.id].outIncidentEdges
 	for i := 0; i < len(vertexList); i++ {
-		temp := vertexList[i]
-		cost := costList[i]
+		temp := vertexList[i].vertexID
+		cost := vertexList[i].cost
 		if graph.Vertices[vertex.id].orderPos < graph.Vertices[temp].orderPos {
 			alt := queryDist[vertex.id] + cost
 			if queryDist[temp] > alt {

--- a/bidirectional_relaxation.go
+++ b/bidirectional_relaxation.go
@@ -28,11 +28,10 @@ func (graph *Graph) relaxEdgesBiForward(vertex *simpleNode, forwQ *forwardPropag
 
 // relaxEdgesBiForward Edge relaxation in a backward propagation
 func (graph *Graph) relaxEdgesBiBackward(vertex *simpleNode, backwQ *backwardPropagationHeap, prev map[int64]int64, revDist []float64) {
-	vertexList := graph.Vertices[vertex.id].inEdges
-	costList := graph.Vertices[vertex.id].inECost
+	vertexList := graph.Vertices[vertex.id].inIncidentEdges
 	for i := 0; i < len(vertexList); i++ {
-		temp := vertexList[i]
-		cost := costList[i]
+		temp := vertexList[i].vertexID
+		cost := vertexList[i].cost
 		if graph.Vertices[vertex.id].orderPos < graph.Vertices[temp].orderPos {
 			alt := revDist[vertex.id] + cost
 			if revDist[temp] > alt {

--- a/contraction.go
+++ b/contraction.go
@@ -34,10 +34,10 @@ func (graph *Graph) Preprocess() []int64 {
 // inEdges Incoming edges from vertex
 // outEdges Outcoming edges from vertex
 //
-func (graph *Graph) callNeighbors(inEdges, outEdges []int64) {
+func (graph *Graph) callNeighbors(inEdges []incidentEdge, outEdges []int64) {
 	for i := 0; i < len(inEdges); i++ {
 		temp := inEdges[i]
-		graph.Vertices[temp].delNeighbors++
+		graph.Vertices[temp.vertexID].delNeighbors++
 	}
 	for i := 0; i < len(outEdges); i++ {
 		temp := outEdges[i]
@@ -61,8 +61,7 @@ type ContractionPath struct {
 // contractID ID of contraction
 //
 func (graph *Graph) contractNode(vertex *Vertex, contractID int64) {
-	inEdges := vertex.inEdges
-	inECost := vertex.inECost
+	inEdges := vertex.inIncidentEdges
 	outEdges := vertex.outEdges
 	outECost := vertex.outECost
 
@@ -71,14 +70,14 @@ func (graph *Graph) contractNode(vertex *Vertex, contractID int64) {
 	inMax := 0.0
 	outMax := 0.0
 
-	graph.callNeighbors(vertex.inEdges, vertex.outEdges)
+	graph.callNeighbors(inEdges, vertex.outEdges)
 
-	for i := 0; i < len(inECost); i++ {
-		if graph.Vertices[inEdges[i]].contracted {
+	for i := 0; i < len(inEdges); i++ {
+		if graph.Vertices[inEdges[i].vertexID].contracted {
 			continue
 		}
-		if inMax < inECost[i] {
-			inMax = inECost[i]
+		if inMax < inEdges[i].cost {
+			inMax = inEdges[i].cost
 		}
 	}
 
@@ -94,11 +93,11 @@ func (graph *Graph) contractNode(vertex *Vertex, contractID int64) {
 	max := inMax + outMax
 
 	for i := 0; i < len(inEdges); i++ {
-		inVertex := inEdges[i]
+		inVertex := inEdges[i].vertexID
 		if graph.Vertices[inVertex].contracted {
 			continue
 		}
-		incost := inECost[i]
+		incost := inEdges[i].cost
 		graph.dijkstra(inVertex, max, contractID, int64(i)) //finds the shortest distances from the inVertex to all the outVertices.
 		for j := 0; j < len(outEdges); j++ {
 			outVertex := outEdges[j]
@@ -122,8 +121,7 @@ func (graph *Graph) contractNode(vertex *Vertex, contractID int64) {
 				}
 				graph.Vertices[inVertex].outEdges = append(graph.Vertices[inVertex].outEdges, outVertex)
 				graph.Vertices[inVertex].outECost = append(graph.Vertices[inVertex].outECost, summaryCost)
-				graph.Vertices[outVertex].inEdges = append(graph.Vertices[outVertex].inEdges, inVertex)
-				graph.Vertices[outVertex].inECost = append(graph.Vertices[outVertex].inECost, summaryCost)
+				graph.Vertices[outVertex].inIncidentEdges = append(graph.Vertices[outVertex].inIncidentEdges, incidentEdge{inVertex, summaryCost})
 			}
 		}
 	}

--- a/dijkstra.go
+++ b/dijkstra.go
@@ -12,11 +12,10 @@ func (graph *Graph) checkID(source, target int64) bool {
 
 // relaxEdges Edge relaxation
 func (graph *Graph) relaxEdges(vertex, contractID, sourceID int64) {
-	vertexList := graph.Vertices[vertex].outEdges
-	costList := graph.Vertices[vertex].outECost
+	vertexList := graph.Vertices[vertex].outIncidentEdges
 	for i := 0; i < len(vertexList); i++ {
-		temp := vertexList[i]
-		cost := costList[i]
+		temp := vertexList[i].vertexID
+		cost := vertexList[i].cost
 		if graph.Vertices[temp].contracted {
 			continue
 		}

--- a/export.go
+++ b/export.go
@@ -90,12 +90,11 @@ func (graph *Graph) ExportToFile(fname string) error {
 
 		// Write reference information about "outcoming" adjacent vertices
 		// Why don't write info about "incoming" adjacent vertices also? Because all edges will be covered due the loop iteration mechanism
-		outcomingNeighbors := graph.Vertices[i].outEdges
-		outcomingCosts := graph.Vertices[i].outECost
+		outcomingNeighbors := graph.Vertices[i].outIncidentEdges
 		for j := 0; j < len(outcomingNeighbors); j++ {
-			toVertexExternal := graph.Vertices[outcomingNeighbors[j]].Label
-			toVertexInternal := outcomingNeighbors[j]
-			cost := outcomingCosts[j]
+			toVertexExternal := graph.Vertices[outcomingNeighbors[j].vertexID].Label
+			toVertexInternal := outcomingNeighbors[j].vertexID
+			cost := outcomingNeighbors[j].cost
 			if _, ok := graph.contracts[currentVertexInternal][toVertexInternal]; !ok {
 				err = writer.Write([]string{
 					fmt.Sprintf("%d", currentVertexExternal),

--- a/graph.go
+++ b/graph.go
@@ -109,9 +109,7 @@ func (graph *Graph) AddEdge(from, to int64, weight float64) error {
 	from = graph.mapping[from]
 	to = graph.mapping[to]
 
-	graph.Vertices[from].outEdges = append(graph.Vertices[from].outEdges, to)
-	graph.Vertices[from].outECost = append(graph.Vertices[from].outECost, weight)
-
+	graph.Vertices[from].outIncidentEdges = append(graph.Vertices[from].outIncidentEdges, incidentEdge{to, weight})
 	graph.Vertices[to].inIncidentEdges = append(graph.Vertices[to].inIncidentEdges, incidentEdge{from, weight})
 	return nil
 }
@@ -150,8 +148,8 @@ func (graph *Graph) computeImportance() {
 	graph.pqImportance = &importanceHeap{}
 	heap.Init(graph.pqImportance)
 	for i := 0; i < len(graph.Vertices); i++ {
-		graph.Vertices[i].edgeDiff = len(graph.Vertices[i].inIncidentEdges)*len(graph.Vertices[i].outEdges) - len(graph.Vertices[i].inIncidentEdges) - len(graph.Vertices[i].outEdges)
-		graph.Vertices[i].shortcutCover = len(graph.Vertices[i].inIncidentEdges) + len(graph.Vertices[i].outEdges)
+		graph.Vertices[i].edgeDiff = len(graph.Vertices[i].inIncidentEdges)*len(graph.Vertices[i].outIncidentEdges) - len(graph.Vertices[i].inIncidentEdges) - len(graph.Vertices[i].outIncidentEdges)
+		graph.Vertices[i].shortcutCover = len(graph.Vertices[i].inIncidentEdges) + len(graph.Vertices[i].outIncidentEdges)
 		graph.Vertices[i].importance = graph.Vertices[i].edgeDiff*14 + graph.Vertices[i].shortcutCover*25 + graph.Vertices[i].delNeighbors*10
 		heap.Push(graph.pqImportance, graph.Vertices[i])
 	}

--- a/graph.go
+++ b/graph.go
@@ -112,8 +112,7 @@ func (graph *Graph) AddEdge(from, to int64, weight float64) error {
 	graph.Vertices[from].outEdges = append(graph.Vertices[from].outEdges, to)
 	graph.Vertices[from].outECost = append(graph.Vertices[from].outECost, weight)
 
-	graph.Vertices[to].inEdges = append(graph.Vertices[to].inEdges, from)
-	graph.Vertices[to].inECost = append(graph.Vertices[to].inECost, weight)
+	graph.Vertices[to].inIncidentEdges = append(graph.Vertices[to].inIncidentEdges, incidentEdge{from, weight})
 	return nil
 }
 
@@ -151,8 +150,8 @@ func (graph *Graph) computeImportance() {
 	graph.pqImportance = &importanceHeap{}
 	heap.Init(graph.pqImportance)
 	for i := 0; i < len(graph.Vertices); i++ {
-		graph.Vertices[i].edgeDiff = len(graph.Vertices[i].inEdges)*len(graph.Vertices[i].outEdges) - len(graph.Vertices[i].inEdges) - len(graph.Vertices[i].outEdges)
-		graph.Vertices[i].shortcutCover = len(graph.Vertices[i].inEdges) + len(graph.Vertices[i].outEdges)
+		graph.Vertices[i].edgeDiff = len(graph.Vertices[i].inIncidentEdges)*len(graph.Vertices[i].outEdges) - len(graph.Vertices[i].inIncidentEdges) - len(graph.Vertices[i].outEdges)
+		graph.Vertices[i].shortcutCover = len(graph.Vertices[i].inIncidentEdges) + len(graph.Vertices[i].outEdges)
 		graph.Vertices[i].importance = graph.Vertices[i].edgeDiff*14 + graph.Vertices[i].shortcutCover*25 + graph.Vertices[i].delNeighbors*10
 		heap.Push(graph.pqImportance, graph.Vertices[i])
 	}

--- a/isochrones.go
+++ b/isochrones.go
@@ -26,18 +26,17 @@ func (graph *Graph) Isochrones(source int64, maxCost float64) (map[int64]float64
 		visit[next.id] = true
 		if next.distance <= maxCost {
 			distance[graph.Vertices[next.id].Label] = next.distance
-			vertexList := graph.Vertices[next.id].outEdges
-			costList := graph.Vertices[next.id].outECost
+			vertexList := graph.Vertices[next.id].outIncidentEdges
 			for i := range vertexList {
-				neighbor := vertexList[i]
+				neighbor := vertexList[i].vertexID
 				if v1, ok1 := graph.contracts[next.id]; ok1 {
 					if _, ok2 := v1[neighbor]; ok2 {
 						// Ignore contract
 						continue
 					}
 				}
-				target := vertexList[i]
-				cost := costList[i]
+				target := vertexList[i].vertexID
+				cost := vertexList[i].cost
 				alt := distance[graph.Vertices[next.id].Label] + cost
 				if visit[target] {
 					continue

--- a/vanilla_dijkstra.go
+++ b/vanilla_dijkstra.go
@@ -62,19 +62,18 @@ func (graph *Graph) VanillaShortestPath(source, target int64) (float64, []int64)
 			break
 		}
 
-		vertexList := graph.Vertices[u.id].outEdges
-		costList := graph.Vertices[u.id].outECost
+		vertexList := graph.Vertices[u.id].outIncidentEdges
 
 		// for each neighbor v of u:
 		for v := range vertexList {
-			neighbor := vertexList[v]
+			neighbor := vertexList[v].vertexID
 			if v1, ok1 := graph.contracts[u.id]; ok1 {
 				if _, ok2 := v1[neighbor]; ok2 {
 					// Ignore contract
 					continue
 				}
 			}
-			cost := costList[v]
+			cost := vertexList[v].cost
 			// alt ← dist[u] + length(u, v)
 			alt := distance[u.id] + cost
 			// if alt < dist[v]

--- a/vanilla_dijkstra_turn_restricted.go
+++ b/vanilla_dijkstra_turn_restricted.go
@@ -73,12 +73,11 @@ func (graph *Graph) VanillaTurnRestrictedShortestPath(source, target int64) (flo
 			break
 		}
 
-		vertexList := graph.Vertices[u.id].outEdges
-		costList := graph.Vertices[u.id].outECost
+		vertexList := graph.Vertices[u.id].outIncidentEdges
 
 		// for each neighbor v of u:
 		for v := range vertexList {
-			neighbor := vertexList[v]
+			neighbor := vertexList[v].vertexID
 			if v1, ok1 := graph.contracts[u.id]; ok1 {
 				if _, ok2 := v1[neighbor]; ok2 {
 					// Ignore contract
@@ -90,7 +89,7 @@ func (graph *Graph) VanillaTurnRestrictedShortestPath(source, target int64) (flo
 				distance[u.id] = math.MaxFloat64
 				continue
 			}
-			cost := costList[v]
+			cost := vertexList[v].cost
 			// alt ← dist[u] + length(u, v)
 			alt := distance[u.id] + cost
 			// if alt < dist[v]

--- a/vertex.go
+++ b/vertex.go
@@ -68,7 +68,7 @@ func (vertex *Vertex) computeImportance() {
 	vertex.importance = vertex.edgeDiff*14 + vertex.shortcutCover*25 + vertex.delNeighbors*10
 }
 
-// incidentEdge incident edge to correspondence
+// incidentEdge incident edge for certain vertex
 type incidentEdge struct {
 	vertexID int64
 	cost     float64

--- a/vertex.go
+++ b/vertex.go
@@ -70,6 +70,12 @@ func (vertex *Vertex) computeImportance() {
 	vertex.importance = vertex.edgeDiff*14 + vertex.shortcutCover*25 + vertex.delNeighbors*10
 }
 
+// incidentEdge incident edge to correspondence
+type incidentEdge struct {
+	vertexID int64
+	cost     float64
+}
+
 // Distance Information about contraction between source vertex and contraction vertex
 type Distance struct {
 	contractID  int64

--- a/vertex.go
+++ b/vertex.go
@@ -9,10 +9,9 @@ type Vertex struct {
 	vertexNum int64
 	Label     int64
 
-	inEdges  []int64
-	inECost  []float64
-	outEdges []int64
-	outECost []float64
+	inIncidentEdges []incidentEdge
+	outEdges        []int64
+	outECost        []float64
 
 	orderPos      int
 	contracted    bool
@@ -65,8 +64,8 @@ func NewVertex(vertexNum int64) *Vertex {
 
 // computeImportance Update importance of vertex
 func (vertex *Vertex) computeImportance() {
-	vertex.edgeDiff = len(vertex.inEdges)*len(vertex.outEdges) - len(vertex.inEdges) - len(vertex.outEdges)
-	vertex.shortcutCover = len(vertex.inEdges) + len(vertex.outEdges)
+	vertex.edgeDiff = len(vertex.inIncidentEdges)*len(vertex.outEdges) - len(vertex.inIncidentEdges) - len(vertex.outEdges)
+	vertex.shortcutCover = len(vertex.inIncidentEdges) + len(vertex.outEdges)
 	vertex.importance = vertex.edgeDiff*14 + vertex.shortcutCover*25 + vertex.delNeighbors*10
 }
 

--- a/vertex.go
+++ b/vertex.go
@@ -9,9 +9,8 @@ type Vertex struct {
 	vertexNum int64
 	Label     int64
 
-	inIncidentEdges []incidentEdge
-	outEdges        []int64
-	outECost        []float64
+	inIncidentEdges  []incidentEdge
+	outIncidentEdges []incidentEdge
 
 	orderPos      int
 	contracted    bool
@@ -64,8 +63,8 @@ func NewVertex(vertexNum int64) *Vertex {
 
 // computeImportance Update importance of vertex
 func (vertex *Vertex) computeImportance() {
-	vertex.edgeDiff = len(vertex.inIncidentEdges)*len(vertex.outEdges) - len(vertex.inIncidentEdges) - len(vertex.outEdges)
-	vertex.shortcutCover = len(vertex.inIncidentEdges) + len(vertex.outEdges)
+	vertex.edgeDiff = len(vertex.inIncidentEdges)*len(vertex.outIncidentEdges) - len(vertex.inIncidentEdges) - len(vertex.outIncidentEdges)
+	vertex.shortcutCover = len(vertex.inIncidentEdges) + len(vertex.outIncidentEdges)
 	vertex.importance = vertex.edgeDiff*14 + vertex.shortcutCover*25 + vertex.delNeighbors*10
 }
 


### PR DESCRIPTION
Vertex struct contains 4 fields currently. They are:
```go
inEdges  []int64
inECost  []float64
outEdges []int64
outECost []float64
```

I think such code has not good readability, so I prepared more readable code, but with same meaning/perfomance/number of allocations:
```go
inIncidentEdges  []incidentEdge
outIncidentEdges []incidentEdge
```
, where incidentEdge is:
```go
// incidentEdge incident edge to correspondence
type incidentEdge struct {
	vertexID int64 // <---- This is replacement for INT64 in inEdges/outEdges 
	cost     float64 // <---- This is replacement for FLOAT64in inECost/outECost 
}
```
