### PR TITLE
Add vertex alternatives support

### DIFF
--- a/bidirectional_ch_test.go
+++ b/bidirectional_ch_test.go
@@ -178,6 +178,98 @@ func TestLittleShortestPath(t *testing.T) {
 	t.Log("TestLittleShortestPath is Ok!")
 }
 
+func TestVertexAlternatives(t *testing.T) {
+	//  S-(1)-0-(1)-1-(1)-2
+	//  |     |     |     |
+	// (2)   (1)   (2)   (2)
+	//  |     |     |     |
+	//  3-(1)-4-(1)-5-(1)-T
+
+	g := Graph{}
+	g.CreateVertex(0)
+	g.CreateVertex(1)
+	g.CreateVertex(2)
+	g.CreateVertex(3)
+	g.CreateVertex(4)
+	g.CreateVertex(5)
+	g.CreateVertex(6)
+	g.AddEdge(0, 1, 1.0)
+	g.AddEdge(0, 4, 1.0)
+	g.AddEdge(1, 2, 1.0)
+	g.AddEdge(1, 5, 2.0)
+	g.AddEdge(3, 4, 1.0)
+	g.AddEdge(4, 5, 1.0)
+
+	expectedPath := []int64{0, 4, 5}
+
+	g.PrepareContractionHierarchies()
+	t.Log("TestVertexAlternatives is starting...")
+	sources := []VertexAlternative{
+		{Label: 0, AdditionalDistance: 1.0},
+		{Label: 3, AdditionalDistance: 2.0},
+	}
+	targets := []VertexAlternative{
+		{Label: 2, AdditionalDistance: 2.0},
+		{Label: 5, AdditionalDistance: 1.0},
+	}
+	ans, path := g.ShortestPathWithAlternatives(sources, targets)
+	t.Log("ShortestPathWithAlternatives returned", ans, path)
+	if len(path) != len(expectedPath) {
+		t.Errorf("Num of vertices in path should be %d, but got %d", len(expectedPath), len(path))
+	}
+	for i := range expectedPath {
+		if path[i] != expectedPath[i] {
+			t.Errorf("Path item %d should be %d, but got %d", i, expectedPath[i], path[i])
+		}
+	}
+	if Round(ans, 0.00005) != Round(4.0, 0.00005) {
+		t.Errorf("Length of path should be 4.0, but got %f", ans)
+	}
+
+	t.Log("TestVertexAlternatives is Ok!")
+}
+
+func TestVertexAlternativesConnected(t *testing.T) {
+	//  S-(1)-0-----\
+	//  |     |     |
+	// (1)   (1)   (3)
+	//  |     |     |
+	//  \-----1-(1)-T
+
+	g := Graph{}
+	g.CreateVertex(0)
+	g.CreateVertex(1)
+	g.AddEdge(0, 1, 1.0)
+
+	expectedPath := []int64{1}
+
+	g.PrepareContractionHierarchies()
+	t.Log("TestVertexAlternativesConnected is starting...")
+	sources := []VertexAlternative{
+		{Label: 0, AdditionalDistance: 1.0},
+		{Label: 1, AdditionalDistance: 1.0},
+	}
+	targets := []VertexAlternative{
+		{Label: 0, AdditionalDistance: 3.0},
+		{Label: 1, AdditionalDistance: 1.0},
+	}
+	ans, path := g.ShortestPathWithAlternatives(sources, targets)
+	t.Log("ShortestPathWithAlternatives returned", ans, path)
+	if len(path) != len(expectedPath) {
+		t.Errorf("Num of vertices in path should be %d, but got %d", len(expectedPath), len(path))
+	}
+	for i := range expectedPath {
+		if path[i] != expectedPath[i] {
+			t.Errorf("Path item %d should be %d, but got %d", i, expectedPath[i], path[i])
+		}
+	}
+	if Round(ans, 0.00005) != Round(2.0, 0.00005) {
+		t.Errorf("Length of path should be 2.0, but got %f", ans)
+	}
+
+	t.Log("TestVertexAlternativesConnected is Ok!")
+}
+
 func graphFromCSV(graph *Graph, fname string) error {
 	file, err := os.Open(fname)
 	if err != nil {

--- a/dijkstra_bidirectional.go
+++ b/dijkstra_bidirectional.go
@@ -22,76 +22,24 @@ func (graph *Graph) ShortestPath(source, target int64) (float64, []int64) {
 	if target, ok = graph.mapping[target]; !ok {
 		return -1.0, nil
 	}
-	return graph.shortestPath([]vertexAlternativeInternal{{vertexNum: source}}, []vertexAlternativeInternal{{vertexNum: target}})
+	return graph.shortestPath(source, target)
 }
 
-type VertexAlternative struct {
-	Label              int64
-	AdditionalDistance float64
-}
-
-// ShortestPathWithAlternatives Computes and returns shortest path and it's cost (extended Dijkstra's algorithm),
-// with multiple alternatives for source and target vertices with additional distances to reach the vertices
-// (useful if source and target are outside of the graph)
-//
-// If there are some errors then function returns '-1.0' as cost and nil as shortest path
-//
-// sources Source vertex alternatives
-// targets Target vertex alternatives
-func (graph *Graph) ShortestPathWithAlternatives(sources, targets []VertexAlternative) (float64, []int64) {
-	sourcesInternal := make([]vertexAlternativeInternal, 0, len(sources))
-	targetsInternal := make([]vertexAlternativeInternal, 0, len(targets))
-	for _, source := range sources {
-		sourceInternal := vertexAlternativeInternal{additionalDistance: source.AdditionalDistance}
-		var ok bool
-		if sourceInternal.vertexNum, ok = graph.mapping[source.Label]; !ok {
-			return -1.0, nil
-		}
-		sourcesInternal = append(sourcesInternal, sourceInternal)
-	}
-	for _, target := range targets {
-		targetInternal := vertexAlternativeInternal{additionalDistance: target.AdditionalDistance}
-		var ok bool
-		if targetInternal.vertexNum, ok = graph.mapping[target.Label]; !ok {
-			return -1.0, nil
-		}
-		targetsInternal = append(targetsInternal, targetInternal)
-	}
-	return graph.shortestPath(sourcesInternal, targetsInternal)
-}
-
-type vertexAlternativeInternal struct {
-	vertexNum          int64
-	additionalDistance float64
-}
-
-func (graph *Graph) shortestPath(sources, targets []vertexAlternativeInternal) (float64, []int64) {
-	forwardPrev := make(map[int64]int64)
-	backwardPrev := make(map[int64]int64)
-
+func (graph *Graph) shortestPath(source, target int64) (float64, []int64) {
 	queryDist := make([]float64, len(graph.Vertices))
 	revQueryDist := make([]float64, len(graph.Vertices))
 
 	forwProcessed := make([]bool, len(graph.Vertices))
 	revProcessed := make([]bool, len(graph.Vertices))
-
-	for _, source := range sources {
-		forwProcessed[source.vertexNum] = true
-	}
-	for _, target := range targets {
-		revProcessed[target.vertexNum] = true
-	}
+	forwProcessed[source] = true
+	revProcessed[target] = true
 
 	for i := range queryDist {
 		queryDist[i] = Infinity
 		revQueryDist[i] = Infinity
 	}
-	for _, source := range sources {
-		queryDist[source.vertexNum] = source.additionalDistance
-	}
-	for _, target := range targets {
-		revQueryDist[target.vertexNum] = target.additionalDistance
-	}
+	queryDist[source] = 0
+	revQueryDist[target] = 0
 
 	forwQ := &forwardHeap{}
 	backwQ := &backwardHeap{}
@@ -99,22 +47,31 @@ func (graph *Graph) shortestPath(sources, targets []vertexAlternativeInternal) (
 	heap.Init(forwQ)
 	heap.Init(backwQ)
 
-	for _, source := range sources {
-		heapSource := &bidirectionalVertex{
-			id:               source.vertexNum,
-			queryDist:        source.additionalDistance,
-			revQueryDistance: Infinity,
-		}
-		heap.Push(forwQ, heapSource)
+	heapSource := &bidirectionalVertex{
+		id:               source,
+		queryDist:        0,
+		revQueryDistance: Infinity,
 	}
-	for _, target := range targets {
-		heapTarget := &bidirectionalVertex{
-			id:               target.vertexNum,
-			queryDist:        Infinity,
-			revQueryDistance: target.additionalDistance,
-		}
-		heap.Push(backwQ, heapTarget)
+	heapTarget := &bidirectionalVertex{
+		id:               target,
+		queryDist:        Infinity,
+		revQueryDistance: 0,
 	}
+
+	heap.Push(forwQ, heapSource)
+	heap.Push(backwQ, heapTarget)
+
+	return graph.shortestPathCore(queryDist, revQueryDist, forwProcessed, revProcessed, forwQ, backwQ)
+}
+
+func (graph *Graph) shortestPathCore(
+	queryDist, revQueryDist []float64,
+	forwProcessed, revProcessed []bool,
+	forwQ *forwardHeap,
+	backwQ *backwardHeap,
+) (float64, []int64) {
+	forwardPrev := make(map[int64]int64)
+	backwardPrev := make(map[int64]int64)
 
 	estimate := Infinity
 
@@ -190,6 +147,97 @@ func (graph *Graph) shortestPath(sources, targets []vertexAlternativeInternal) (
 		return -1.0, nil
 	}
 	return estimate, graph.ComputePath(middleID, forwardPrev, backwardPrev)
+}
+
+type VertexAlternative struct {
+	Label              int64
+	AdditionalDistance float64
+}
+
+// ShortestPathWithAlternatives Computes and returns shortest path and it's cost (extended Dijkstra's algorithm),
+// with multiple alternatives for source and target vertices with additional distances to reach the vertices
+// (useful if source and target are outside of the graph)
+//
+// If there are some errors then function returns '-1.0' as cost and nil as shortest path
+//
+// sources Source vertex alternatives
+// targets Target vertex alternatives
+func (graph *Graph) ShortestPathWithAlternatives(sources, targets []VertexAlternative) (float64, []int64) {
+	sourcesInternal := make([]vertexAlternativeInternal, 0, len(sources))
+	targetsInternal := make([]vertexAlternativeInternal, 0, len(targets))
+	for _, source := range sources {
+		sourceInternal := vertexAlternativeInternal{additionalDistance: source.AdditionalDistance}
+		var ok bool
+		if sourceInternal.vertexNum, ok = graph.mapping[source.Label]; !ok {
+			return -1.0, nil
+		}
+		sourcesInternal = append(sourcesInternal, sourceInternal)
+	}
+	for _, target := range targets {
+		targetInternal := vertexAlternativeInternal{additionalDistance: target.AdditionalDistance}
+		var ok bool
+		if targetInternal.vertexNum, ok = graph.mapping[target.Label]; !ok {
+			return -1.0, nil
+		}
+		targetsInternal = append(targetsInternal, targetInternal)
+	}
+	return graph.shortestPathWithAlternatives(sourcesInternal, targetsInternal)
+}
+
+type vertexAlternativeInternal struct {
+	vertexNum          int64
+	additionalDistance float64
+}
+
+func (graph *Graph) shortestPathWithAlternatives(sources, targets []vertexAlternativeInternal) (float64, []int64) {
+	queryDist := make([]float64, len(graph.Vertices))
+	revQueryDist := make([]float64, len(graph.Vertices))
+
+	forwProcessed := make([]bool, len(graph.Vertices))
+	revProcessed := make([]bool, len(graph.Vertices))
+
+	for _, source := range sources {
+		forwProcessed[source.vertexNum] = true
+	}
+	for _, target := range targets {
+		revProcessed[target.vertexNum] = true
+	}
+
+	for i := range queryDist {
+		queryDist[i] = Infinity
+		revQueryDist[i] = Infinity
+	}
+	for _, source := range sources {
+		queryDist[source.vertexNum] = source.additionalDistance
+	}
+	for _, target := range targets {
+		revQueryDist[target.vertexNum] = target.additionalDistance
+	}
+
+	forwQ := &forwardHeap{}
+	backwQ := &backwardHeap{}
+
+	heap.Init(forwQ)
+	heap.Init(backwQ)
+
+	for _, source := range sources {
+		heapSource := &bidirectionalVertex{
+			id:               source.vertexNum,
+			queryDist:        source.additionalDistance,
+			revQueryDistance: Infinity,
+		}
+		heap.Push(forwQ, heapSource)
+	}
+	for _, target := range targets {
+		heapTarget := &bidirectionalVertex{
+			id:               target.vertexNum,
+			queryDist:        Infinity,
+			revQueryDistance: target.additionalDistance,
+		}
+		heap.Push(backwQ, heapTarget)
+	}
+
+	return graph.shortestPathCore(queryDist, revQueryDist, forwProcessed, revProcessed, forwQ, backwQ)
 }
 
 // ComputePath Returns slice of IDs (user defined) of computed path

--- a/dijkstra_bidirectional.go
+++ b/dijkstra_bidirectional.go
@@ -207,19 +207,7 @@ func (graph *Graph) shortestPathWithAlternatives(sources, targets []vertexAltern
 
 	for _, source := range sources {
 		forwProcessed[source.vertexNum] = true
-	}
-	for _, target := range targets {
-		revProcessed[target.vertexNum] = true
-	}
-
-	for _, source := range sources {
 		queryDist[source.vertexNum] = source.additionalDistance
-	}
-	for _, target := range targets {
-		revQueryDist[target.vertexNum] = target.additionalDistance
-	}
-
-	for _, source := range sources {
 		heapSource := &bidirectionalVertex{
 			id:               source.vertexNum,
 			queryDist:        source.additionalDistance,
@@ -228,6 +216,8 @@ func (graph *Graph) shortestPathWithAlternatives(sources, targets []vertexAltern
 		heap.Push(forwQ, heapSource)
 	}
 	for _, target := range targets {
+		revProcessed[target.vertexNum] = true
+		revQueryDist[target.vertexNum] = target.additionalDistance
 		heapTarget := &bidirectionalVertex{
 			id:               target.vertexNum,
 			queryDist:        Infinity,


### PR DESCRIPTION
This change allows specifying multiple source and destination nodes. If source and/or target are not exactly on the graph nodes, this allows passing multiple close-by nodes with associated distance to them.