### PR TITLE
Remove pointer slices and increase performance

### DIFF
--- a/bidirectional_ch_n_to_n.go
+++ b/bidirectional_ch_n_to_n.go
@@ -23,19 +23,14 @@ func (graph *Graph) ShortestPathManyToMany(sources, targets []int64) ([][]float6
 	return graph.shortestPathManyToMany(endpoints)
 }
 
-func (graph *Graph) initShortestPathManyToMany(endpointCounts [directionsCount]int) (queryDist [directionsCount][][]float64, processed [directionsCount][][]bool, queues [directionsCount][]*vertexDistHeap) {
+func (graph *Graph) initShortestPathManyToMany(endpointCounts [directionsCount]int) (queryDist [directionsCount][]verticesDistance, processed [directionsCount][]map[int64]bool, queues [directionsCount][]*vertexDistHeap) {
 	for d := forward; d < directionsCount; d++ {
-		queryDist[d] = make([][]float64, endpointCounts[d])
-		processed[d] = make([][]bool, endpointCounts[d])
+		queryDist[d] = make([]verticesDistance, endpointCounts[d])
+		processed[d] = make([]map[int64]bool, endpointCounts[d])
 		queues[d] = make([]*vertexDistHeap, endpointCounts[d])
 		for endpointIdx := 0; endpointIdx < endpointCounts[d]; endpointIdx++ {
-			queryDist[d][endpointIdx] = make([]float64, len(graph.Vertices))
-
-			for i := range queryDist[d][endpointIdx] {
-				queryDist[d][endpointIdx][i] = Infinity
-			}
-
-			processed[d][endpointIdx] = make([]bool, len(graph.Vertices))
+			queryDist[d][endpointIdx] = make(map[int64]float64)
+			processed[d][endpointIdx] = make(map[int64]bool)
 
 			queues[d][endpointIdx] = &vertexDistHeap{}
 
@@ -50,7 +45,7 @@ func (graph *Graph) shortestPathManyToMany(endpoints [directionsCount][]int64) (
 	for d := forward; d < directionsCount; d++ {
 		for endpointIdx, endpoint := range endpoints[d] {
 			processed[d][endpointIdx][endpoint] = true
-			queryDist[d][endpointIdx][endpoint] = 0
+			queryDist[d][endpointIdx].setVerticeDistance(endpoint, 0)
 			heapEndpoint := &vertexDist{
 				id:   endpoint,
 				dist: 0,
@@ -61,7 +56,7 @@ func (graph *Graph) shortestPathManyToMany(endpoints [directionsCount][]int64) (
 	return graph.shortestPathManyToManyCore(queryDist, processed, queues)
 }
 
-func (graph *Graph) shortestPathManyToManyCore(queryDist [directionsCount][][]float64, processed [directionsCount][][]bool, queues [directionsCount][]*vertexDistHeap) ([][]float64, [][][]int64) {
+func (graph *Graph) shortestPathManyToManyCore(queryDist [directionsCount][]verticesDistance, processed [directionsCount][]map[int64]bool, queues [directionsCount][]*vertexDistHeap) ([][]float64, [][][]int64) {
 	var prev [directionsCount][]map[int64]int64
 	for d := forward; d < directionsCount; d++ {
 		prev[d] = make([]map[int64]int64, len(queues[d]))
@@ -115,8 +110,8 @@ func (graph *Graph) shortestPathManyToManyCore(queryDist [directionsCount][][]fl
 
 func (graph *Graph) directionalSearchManyToMany(
 	d direction, endpointIndex int, q *vertexDistHeap,
-	localProcessed []bool, reverseProcessed [][]bool,
-	localQueryDist []float64, reverseQueryDist [][]float64,
+	localProcessed map[int64]bool, reverseProcessed []map[int64]bool,
+	localQueryDist verticesDistance, reverseQueryDist []verticesDistance,
 	prev map[int64]int64, estimates [][]float64, middleIDs [][]int64) {
 
 	vertex := heap.Pop(q).(*vertexDist)
@@ -136,9 +131,9 @@ func (graph *Graph) directionalSearchManyToMany(
 		temp := vertexList[i].vertexID
 		cost := vertexList[i].weight
 		if graph.Vertices[vertex.id].orderPos < graph.Vertices[temp].orderPos {
-			alt := localQueryDist[vertex.id] + cost
-			if localQueryDist[temp] > alt {
-				localQueryDist[temp] = alt
+			alt := localQueryDist.getVerticeDistance(vertex.id) + cost
+			if localQueryDist.getVerticeDistance(temp) > alt {
+				localQueryDist.setVerticeDistance(temp, alt)
 				prev[temp] = vertex.id
 				node := &vertexDist{
 					id:   temp,
@@ -160,9 +155,9 @@ func (graph *Graph) directionalSearchManyToMany(
 			} else {
 				targetEndpoint, sourceEndpoint = endpointIndex, revEndpointIdx
 			}
-			if vertex.dist+reverseQueryDist[revEndpointIdx][vertex.id] < estimates[sourceEndpoint][targetEndpoint] {
+			if vertex.dist+reverseQueryDist[revEndpointIdx].getVerticeDistance(vertex.id) < estimates[sourceEndpoint][targetEndpoint] {
 				middleIDs[sourceEndpoint][targetEndpoint] = vertex.id
-				estimates[sourceEndpoint][targetEndpoint] = vertex.dist + reverseQueryDist[revEndpointIdx][vertex.id]
+				estimates[sourceEndpoint][targetEndpoint] = vertex.dist + reverseQueryDist[revEndpointIdx].getVerticeDistance(vertex.id)
 				if graph.Reporter != nil {
 					graph.Reporter.FoundBetterPath(int(d), sourceEndpoint, targetEndpoint, vertex.id, estimates[sourceEndpoint][targetEndpoint])
 				}
@@ -200,7 +195,7 @@ func (graph *Graph) shortestPathManyToManyWithAlternatives(endpoints [directions
 					continue
 				}
 				processed[d][endpointIdx][endpointAlternative.vertexNum] = true
-				queryDist[d][endpointIdx][endpointAlternative.vertexNum] = endpointAlternative.additionalDistance
+				queryDist[d][endpointIdx].setVerticeDistance(endpointAlternative.vertexNum, endpointAlternative.additionalDistance)
 				heapEndpoint := &vertexDist{
 					id:   endpointAlternative.vertexNum,
 					dist: endpointAlternative.additionalDistance,
@@ -210,4 +205,19 @@ func (graph *Graph) shortestPathManyToManyWithAlternatives(endpoints [directions
 		}
 	}
 	return graph.shortestPathManyToManyCore(queryDist, processed, queues)
+}
+
+type verticesDistance map[int64]float64
+
+func (vd verticesDistance) getVerticeDistance(verticeId int64) float64 {
+	dist, ok := vd[verticeId]
+	if !ok {
+		return Infinity
+	}
+
+	return dist
+}
+
+func (vd verticesDistance) setVerticeDistance(verticeId int64, distance float64) {
+	vd[verticeId] = distance
 }

--- a/bidirectional_ch_n_to_n.go
+++ b/bidirectional_ch_n_to_n.go
@@ -122,6 +122,9 @@ func (graph *Graph) directionalSearchManyToMany(
 	vertex := heap.Pop(q).(*vertexDist)
 	// if vertex.dist <= *estimate { // TODO: move to another place
 	localProcessed[vertex.id] = true
+	if graph.Reporter != nil {
+		graph.Reporter.VertexSettled(int(d), endpointIndex, vertex.id, q.Len())
+	}
 	// Edge relaxation in a forward propagation
 	var vertexList []*incidentEdge
 	if d == forward {
@@ -142,6 +145,9 @@ func (graph *Graph) directionalSearchManyToMany(
 					dist: alt,
 				}
 				heap.Push(q, node)
+				if graph.Reporter != nil {
+					graph.Reporter.EdgeRelaxed(int(d), endpointIndex, vertex.id, temp, true, q.Len())
+				}
 			}
 		}
 	}
@@ -157,6 +163,9 @@ func (graph *Graph) directionalSearchManyToMany(
 			if vertex.dist+reverseQueryDist[revEndpointIdx][vertex.id] < estimates[sourceEndpoint][targetEndpoint] {
 				middleIDs[sourceEndpoint][targetEndpoint] = vertex.id
 				estimates[sourceEndpoint][targetEndpoint] = vertex.dist + reverseQueryDist[revEndpointIdx][vertex.id]
+				if graph.Reporter != nil {
+					graph.Reporter.FoundBetterPath(int(d), sourceEndpoint, targetEndpoint, vertex.id, estimates[sourceEndpoint][targetEndpoint])
+				}
 			}
 		}
 	}

--- a/bidirectional_ch_n_to_n.go
+++ b/bidirectional_ch_n_to_n.go
@@ -121,7 +121,7 @@ func (graph *Graph) directionalSearchManyToMany(
 		graph.Reporter.VertexSettled(int(d), endpointIndex, vertex.id, q.Len())
 	}
 	// Edge relaxation in a forward propagation
-	var vertexList []*incidentEdge
+	var vertexList []incidentEdge
 	if d == forward {
 		vertexList = graph.Vertices[vertex.id].outIncidentEdges
 	} else {

--- a/contraction.go
+++ b/contraction.go
@@ -39,8 +39,7 @@ func (graph *Graph) Preprocess(pqImportance *importanceHeap) {
 //
 // inEdges Incoming edges from vertex
 // outEdges Outcoming edges from vertex
-//
-func (graph *Graph) markNeighbors(inEdges, outEdges []*incidentEdge) {
+func (graph *Graph) markNeighbors(inEdges, outEdges []incidentEdge) {
 	for i := range inEdges {
 		temp := inEdges[i]
 		graph.Vertices[temp.vertexID].delNeighbors++
@@ -54,7 +53,6 @@ func (graph *Graph) markNeighbors(inEdges, outEdges []*incidentEdge) {
 // contractNode
 //
 // vertex Vertex to be contracted
-//
 func (graph *Graph) contractNode(vertex *Vertex) {
 	// Consider all vertices with edges incoming TO current vertex as U
 	incomingEdges := vertex.inIncidentEdges
@@ -97,7 +95,6 @@ func (graph *Graph) contractNode(vertex *Vertex) {
 //
 // vertex - Vertex for making possible shortcuts around
 // pmax - path cost restriction
-//
 func (graph *Graph) processIncidentEdges(vertex *Vertex, pmax float64) {
 	incomingEdges := vertex.inIncidentEdges
 	outcomingEdges := vertex.outIncidentEdges
@@ -107,8 +104,7 @@ func (graph *Graph) processIncidentEdges(vertex *Vertex, pmax float64) {
 	batchShortcuts := make([]*ShortcutPath, 0, len(incomingEdges)*len(outcomingEdges))
 
 	previousOrderPos := int64(vertex.orderPos - 1)
-	for i := range incomingEdges {
-		u := incomingEdges[i]
+	for _, u := range incomingEdges {
 		inVertex := u.vertexID
 		// Do not consider any vertex has been excluded earlier
 		if graph.Vertices[inVertex].contracted {
@@ -116,8 +112,7 @@ func (graph *Graph) processIncidentEdges(vertex *Vertex, pmax float64) {
 		}
 		inCost := u.weight
 		graph.shortestPathsWithMaxCost(inVertex, pmax, previousOrderPos) // Finds the shortest distances from the inVertex to all outVertices.
-		for j := range outcomingEdges {
-			w := outcomingEdges[j]
+		for _, w := range outcomingEdges {
 			outVertex := w.vertexID
 			outVertexPtr := graph.Vertices[outVertex]
 			// Do not consider any vertex has been excluded earlier
@@ -154,7 +149,6 @@ func (graph *Graph) insertShortcuts(shortcuts []*ShortcutPath) {
 // fromVertex - Library defined ID of target vertex where shortcut leads to
 // viaVertex - Library defined ID of vertex through which the shortcut exists
 // summaryCost - Travel path of a shortcut
-//
 func (graph *Graph) createOrUpdateShortcut(fromVertex, toVertex, viaVertex int64, summaryCost float64) {
 	if _, ok := graph.shortcuts[fromVertex]; !ok {
 		// If there is no such shortcut then add one.

--- a/dijkstra_bidirectional.go
+++ b/dijkstra_bidirectional.go
@@ -89,6 +89,9 @@ func (graph *Graph) shortestPathCore(queryDist [directionsCount][]float64, proce
 
 func (graph *Graph) directionalSearch(d direction, q *vertexDistHeap, localProcessed, reverseProcessed []bool, localQueryDist, reverseQueryDist []float64, prev map[int64]int64, estimate *float64, middleID *int64) {
 	vertex := heap.Pop(q).(*vertexDist)
+	if graph.Reporter != nil {
+		graph.Reporter.VertexSettled(int(d), 0, vertex.id, q.Len())
+	}
 	if vertex.dist <= *estimate {
 		localProcessed[vertex.id] = true
 		// Edge relaxation in a forward propagation
@@ -104,6 +107,11 @@ func (graph *Graph) directionalSearch(d direction, q *vertexDistHeap, localProce
 			if graph.Vertices[vertex.id].orderPos < graph.Vertices[temp].orderPos {
 				alt := localQueryDist[vertex.id] + cost
 				if localQueryDist[temp] > alt {
+					if graph.Reporter != nil {
+						if graph.Reporter != nil {
+							graph.Reporter.EdgeRelaxed(int(d), 0, vertex.id, temp, true, q.Len())
+						}
+					}
 					localQueryDist[temp] = alt
 					prev[temp] = vertex.id
 					node := &vertexDist{
@@ -119,6 +127,9 @@ func (graph *Graph) directionalSearch(d direction, q *vertexDistHeap, localProce
 		if vertex.dist+reverseQueryDist[vertex.id] < *estimate {
 			*middleID = vertex.id
 			*estimate = vertex.dist + reverseQueryDist[vertex.id]
+			if graph.Reporter != nil {
+				graph.Reporter.FoundBetterPath(int(d), 0, 0, vertex.id, *estimate)
+			}
 		}
 	}
 }

--- a/dijkstra_bidirectional.go
+++ b/dijkstra_bidirectional.go
@@ -95,7 +95,7 @@ func (graph *Graph) directionalSearch(d direction, q *vertexDistHeap, localProce
 	if vertex.dist <= *estimate {
 		localProcessed[vertex.id] = true
 		// Edge relaxation in a forward propagation
-		var vertexList []*incidentEdge
+		var vertexList []incidentEdge
 		if d == forward {
 			vertexList = graph.Vertices[vertex.id].outIncidentEdges
 		} else {

--- a/graph.go
+++ b/graph.go
@@ -11,7 +11,6 @@ import (
 // mapping Internal map for 1:1 relation of internal IDs to user's IDs
 // Vertices Slice of vertices of graph
 // shortcuts Found and stored shortcuts based on contraction hierarchies
-//
 type Graph struct {
 	shortcuts    map[int64]map[int64]*ShortcutPath
 	restrictions map[int64]map[int64]int64
@@ -23,6 +22,14 @@ type Graph struct {
 
 	frozen  bool
 	verbose bool
+
+	Reporter Reporter
+}
+
+type Reporter interface {
+	VertexSettled(direction, endpointIndex int, vertexID int64, heapSize int)
+	EdgeRelaxed(direction, endpointIndex int, vertexID, toVertexID int64, ch bool, heapSize int)
+	FoundBetterPath(direction, sourceEndpointIndex, targetEndpointIndex int, vertexID int64, estimate float64)
 }
 
 // NewGraph returns pointer to created Graph and does preallocations for processing purposes
@@ -42,7 +49,6 @@ func NewGraph() *Graph {
 // CreateVertex Creates new vertex and assign internal ID to it
 //
 // label User's definied ID of vertex
-//
 func (graph *Graph) CreateVertex(label int64) error {
 	if graph.frozen {
 		return ErrGraphIsFrozen
@@ -73,7 +79,6 @@ func (graph *Graph) CreateVertex(label int64) error {
 // from User's definied ID of first vertex of edge
 // to User's definied ID of last vertex of edge
 // weight User's definied weight of edge
-//
 func (graph *Graph) AddEdge(from, to int64, weight float64) error {
 	if graph.frozen {
 		return ErrGraphIsFrozen
@@ -97,7 +102,6 @@ func (graph *Graph) addEdge(from, to int64, weight float64) {
 // to - User's definied ID of last vertex of shortcut
 // via - User's defined ID of vertex through which the shortcut exists
 // weight - User's definied weight of shortcut
-//
 func (graph *Graph) AddShortcut(from, to, via int64, weight float64) error {
 	if graph.frozen {
 		return ErrGraphIsFrozen
@@ -179,7 +183,6 @@ func (graph *Graph) GetEdgesNum() int64 {
 // from User's definied ID of source vertex
 // via User's definied ID of prohibited vertex (between source and target)
 // to User's definied ID of target vertex
-//
 func (graph *Graph) AddTurnRestriction(from, via, to int64) error {
 	if graph.frozen {
 		return ErrGraphIsFrozen

--- a/graph.go
+++ b/graph.go
@@ -92,8 +92,8 @@ func (graph *Graph) AddEdge(from, to int64, weight float64) error {
 }
 
 func (graph *Graph) addEdge(from, to int64, weight float64) {
-	graph.Vertices[from].outIncidentEdges = append(graph.Vertices[from].outIncidentEdges, &incidentEdge{vertexID: to, weight: weight})
-	graph.Vertices[to].inIncidentEdges = append(graph.Vertices[to].inIncidentEdges, &incidentEdge{vertexID: from, weight: weight})
+	graph.Vertices[from].outIncidentEdges = append(graph.Vertices[from].outIncidentEdges, incidentEdge{vertexID: to, weight: weight})
+	graph.Vertices[to].inIncidentEdges = append(graph.Vertices[to].inIncidentEdges, incidentEdge{vertexID: from, weight: weight})
 }
 
 // AddShortcut Adds new shortcut between two vertices

--- a/incident_edge.go
+++ b/incident_edge.go
@@ -11,7 +11,7 @@ type incidentEdge struct {
 // incomingVertexID - Library defined ID of vertex
 // weight - Travel cost of incoming edge
 func (vertex *Vertex) addInIncidentEdge(incomingVertexID int64, weight float64) {
-	vertex.inIncidentEdges = append(vertex.inIncidentEdges, &incidentEdge{incomingVertexID, weight})
+	vertex.inIncidentEdges = append(vertex.inIncidentEdges, incidentEdge{incomingVertexID, weight})
 }
 
 // addOutIncidentEdge Adds incident edge's to pool of "outcoming" edges of given vertex.
@@ -19,7 +19,7 @@ func (vertex *Vertex) addInIncidentEdge(incomingVertexID int64, weight float64) 
 // outcomingVertexID - Library defined ID of vertex
 // weight - Travel cost of outcoming edge
 func (vertex *Vertex) addOutIncidentEdge(outcomingVertexID int64, weight float64) {
-	vertex.outIncidentEdges = append(vertex.outIncidentEdges, &incidentEdge{outcomingVertexID, weight})
+	vertex.outIncidentEdges = append(vertex.outIncidentEdges, incidentEdge{outcomingVertexID, weight})
 }
 
 // findInIncidentEdge Returns index of incoming incident edge by vertex ID

--- a/vanilla_dijkstra.go
+++ b/vanilla_dijkstra.go
@@ -54,6 +54,9 @@ func (graph *Graph) VanillaShortestPath(source, target int64) (float64, []int64)
 	for Q.Len() != 0 {
 		// u ← Q.extract_min()
 		u := heap.Pop(Q).(*minHeapVertex)
+		if graph.Reporter != nil {
+			graph.Reporter.VertexSettled(0, 0, u.id, Q.Len())
+		}
 
 		// if u == target:
 		if u.id == target {
@@ -84,6 +87,9 @@ func (graph *Graph) VanillaShortestPath(source, target int64) (float64, []int64)
 				// Q.decrease_priority(v, alt)
 				// Q.decrease_priority(v, alt)
 				Q.add_with_priority(neighbor, alt)
+				if graph.Reporter != nil {
+					graph.Reporter.EdgeRelaxed(0, 0, u.id, neighbor, false, Q.Len())
+				}
 			}
 		}
 		// heap.Init(Q)
@@ -91,6 +97,9 @@ func (graph *Graph) VanillaShortestPath(source, target int64) (float64, []int64)
 
 	if distance[target] == Infinity {
 		return -1, []int64{}
+	}
+	if graph.Reporter != nil {
+		graph.Reporter.FoundBetterPath(0, 0, 0, -1, distance[target])
 	}
 	// path = []
 	var path []int64

--- a/vertex.go
+++ b/vertex.go
@@ -2,9 +2,9 @@ package ch
 
 // Vertex All information about vertex
 type Vertex struct {
-	distance         *Distance
-	inIncidentEdges  []*incidentEdge
-	outIncidentEdges []*incidentEdge
+	distance         Distance
+	inIncidentEdges  []incidentEdge
+	outIncidentEdges []incidentEdge
 
 	vertexNum int64
 	Label     int64
@@ -86,8 +86,8 @@ type Distance struct {
 }
 
 // NewDistance Constructor for Distance
-func NewDistance() *Distance {
-	return &Distance{
+func NewDistance() Distance {
+	return Distance{
 		previousOrderPos: -1,
 		previousSourceID: -1,
 		distance:         Infinity,
@@ -98,7 +98,6 @@ func NewDistance() *Distance {
 //
 // labelExternal - User defined ID of vertex
 // If vertex is not found then returns (-1; false)
-//
 func (graph *Graph) FindVertex(labelExternal int64) (idx int64, ok bool) {
 	idx, ok = graph.mapping[labelExternal]
 	if !ok {


### PR DESCRIPTION
https://medium.com/@philpearl/bad-go-slices-of-pointers-ed3c06b8bb41
Using pointers with slices in Golang often causes bad errors since the slices are pointers by default. When iterating them , it bloats L caches and prevents them from caching the page of slice which will increase iteration and lookup performance .
Benchmarks with previous and current version is :
Previous version:

Fixed Version:

Difference: